### PR TITLE
set proper BLOCK_INTERVAL parameter

### DIFF
--- a/steemapi/steemnoderpc.py
+++ b/steemapi/steemnoderpc.py
@@ -116,7 +116,7 @@ class SteemNodeRPC(GrapheneWebsocketRPC):
         """
         # Let's find out how often blocks are generated!
         config = self.get_config()
-        block_interval = config["GOLOSIT_BLOCK_INTERVAL"]
+        block_interval = config["STEEMIT_BLOCK_INTERVAL"]
 
         if not start:
             props = self.get_dynamic_global_properties()


### PR DESCRIPTION
There is no GOLOS_BLOCK_INTERVAL parameter in respond to get_config() API request. Can be checked from cl using curl:
curl -sd '{"id":314,"method":"call","params":[0,"get_config",[]]}' http://127.0.0.1:8090
STEEMIT_BLOCK_INTERVAL should be used instead